### PR TITLE
Use up-to-date link for Pygments styles

### DIFF
--- a/src/syntax_highlighting_ng/config.md
+++ b/src/syntax_highlighting_ng/config.md
@@ -4,4 +4,4 @@ These advanced settings do not sync and require a restart to apply.
 
 - `hotkey` [string]: Add-on invocation hotkey. Default: `Alt+S`
 - `limitToLags` [list]: List of programming languages to limit combobox menu to. Default: `[]` (i.e. no limit). Example: `["Python", "Java", "JavaScript"]`. 
-- `style` [string]: Pre-defined [pygments style](https://help.farbox.com/pygments.html) to use for inline styling of code (not applicable to CSS mode). Default: `default`. Example: `monokai`.
+- `style` [string]: Pre-defined [pygments style](https://pygments.org/styles/) to use for inline styling of code (not applicable to CSS mode). Default: `default`. Example: `monokai`.


### PR DESCRIPTION
#### Description

This up updates the link for Pygments styles to something up-to-date -- the previous URL seems to go to a dead page.
